### PR TITLE
fix: install only platform specific file

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,50 +1,107 @@
 #!/usr/bin/env node
 const path = require('path');
-const { execFile, execSync } = require('child_process');
+const { execSync } = require('child_process');
 const os = require('os');
 const fs = require('fs');
+const https = require('https');
 
-let binary;
-
-let arch = os.arch() == 'x64' ? 'amd64_v1' : os.arch();
-let platform = os.platform() == 'win32' ? 'windows' : os.platform();
-let folderName = 'basic-cli' + '_' + platform + '_' + arch;
-
-switch (os.platform()) {
-  case 'win32':
-    binary = path.join(__dirname, 'dist', folderName, 'basic-cli.exe');
-    break;
-  case 'darwin':
-    binary = path.join(__dirname, 'dist', folderName, 'basic-cli');
-    break;
-  case 'linux':
-    binary = path.join(__dirname, 'dist', folderName, 'basic-cli');
-    break;
-  default:
-    console.error('Unsupported OS');
-    process.exit(1);
-}
-
-if (!fs.existsSync(binary)) {
-  console.error(`Binary not found: ${binary}`);
-  process.exit(1);
-}
+const REPO_OWNER = 'basicdb';
+const REPO_NAME = 'basic-cli';
 
 
-const sourcePath = binary
-const fileName = platform == 'windows' ? 'basic-cli.exe' : 'basic-cli'
-const destPath = path.join(__dirname, 'bin', fileName);
+const downloadBinary = async (url, dest) => {
+  return new Promise((resolve, reject) => {
+    const file = fs.createWriteStream(dest);
 
-try {
-  // Ensure the bin directory exists
-  fs.mkdirSync(path.dirname(destPath), { recursive: true });
-  
-  fs.copyFileSync(sourcePath, destPath);
-  if (os.platform() !== 'win32') {
+    const makeRequest = (url) => {
+      https
+        .get(url, (response) => {
+          if (response.statusCode === 302 && response.headers.location) {
+            console.log(`Redirecting to ${response.headers.location}`);
+            makeRequest(response.headers.location);
+          } else if (response.statusCode === 200) {
+            response.pipe(file);
+            file.on('finish', () => {
+              file.close(() => resolve());
+            });
+          } else {
+            reject(
+              new Error(
+                `Failed to download binary: ${response.statusCode} - ${response.statusMessage}`
+              )
+            );
+          }
+        })
+        .on('error', (err) => {
+          fs.unlink(dest, () => reject(err));
+        });
+    };
+
+    makeRequest(url);
+  });
+};
+
+const getPackageVersion = () => {
+  const packageJsonPath = path.join(__dirname, 'package.json');
+  if (!fs.existsSync(packageJsonPath)) {
+    throw new Error('package.json not found');
+  }
+
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+  return packageJson.version;
+};
+
+const installBinary = async () => {
+  const archMap = {
+    x64: 'x86_64',
+    arm64: 'arm64',
+    ia32: 'i386',
+  };
+
+  const platformMap = {
+    win32: 'Windows',
+    darwin: 'Darwin',
+    linux: 'Linux',
+  };
+
+  const arch = archMap[os.arch()] || os.arch();
+  const platform = platformMap[os.platform()] || os.platform();
+  const version = getPackageVersion();
+  if (!arch || !platform) {
+    throw new Error(`Unsupported platform/architecture: ${os.platform()}/${os.arch()}`);
+  }
+
+  const extension = platform === 'Windows' ? 'zip' : 'tar.gz';
+  const fileName = `basic-cli_${platform}_${arch}.${extension}`;
+
+  const destPath = path.join(__dirname, 'bin', `basic-cli${platform === 'Windows' ? '.exe' : ''}`);
+  const tempPath = path.join(__dirname, fileName);
+  const downloadUrl = `https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/v${version}/${fileName}`;
+  console.log(`Downloading binary from ${downloadUrl}`);
+  await downloadBinary(downloadUrl, tempPath);
+
+  if (platform === 'Windows') {
+    execSync(`tar -xf ${tempPath} -C ${path.dirname(destPath)}`);
+  } else {
+    execSync(`tar -xzf ${tempPath} -C ${path.dirname(destPath)}`);
+  }
+
+  fs.unlinkSync(tempPath);
+
+  if (platform !== 'Windows') {
     execSync(`chmod +x ${destPath}`);
   }
-  console.log(`Installed the ${os.platform()} binary.`);
-} catch (error) {
-  console.error('Error during post-install script:', error);
-  process.exit(1);
-}
+
+  console.log(`Installed ${platform} binary to ${destPath}`);
+};
+
+const main = async () => {
+  try {
+    await installBinary();
+  } catch (err) {
+    console.error('Error:', err.message);
+    process.exit(1);
+  }
+};
+
+main();

--- a/index.js
+++ b/index.js
@@ -98,6 +98,7 @@ const installBinary = async () => {
 const main = async () => {
   try {
     await installBinary();
+    process.exit(0);
   } catch (err) {
     console.error('Error:', err.message);
     process.exit(1);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basictech/cli",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "basictech cli for creating & managing your projects",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basictech/cli",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "basictech cli for creating & managing your projects",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "@basictech/cli",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "basictech cli for creating & managing your projects",
   "main": "index.js",
   "files": [
-    "dist",
     "index.js"
   ],
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basictech/cli",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "basictech cli for creating & managing your projects",
   "main": "index.js",
   "files": [
@@ -10,7 +10,7 @@
     "basic": "./bin/basic-cli"
   },
   "scripts": {
-    "postinstall": "node ./index.js",
+    "preinstall": "node ./index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "raz@basic.tech",

--- a/src/main.go
+++ b/src/main.go
@@ -43,7 +43,7 @@ var (
 const (
 	basicCliDirName = ".basic-cli"
 	tokenFileName   = "token.json"
-	version         = "0.0.12"
+	version         = "0.0.13"
 )
 
 type Styles struct {

--- a/src/main.go
+++ b/src/main.go
@@ -43,7 +43,7 @@ var (
 const (
 	basicCliDirName = ".basic-cli"
 	tokenFileName   = "token.json"
-	version         = "0.0.14"
+	version         = "0.0.15"
 )
 
 type Styles struct {

--- a/src/main.go
+++ b/src/main.go
@@ -43,7 +43,7 @@ var (
 const (
 	basicCliDirName = ".basic-cli"
 	tokenFileName   = "token.json"
-	version         = "0.0.13"
+	version         = "0.0.14"
 )
 
 type Styles struct {

--- a/src/main.go
+++ b/src/main.go
@@ -43,7 +43,7 @@ var (
 const (
 	basicCliDirName = ".basic-cli"
 	tokenFileName   = "token.json"
-	version         = "0.0.15"
+	version         = "0.0.16"
 )
 
 type Styles struct {


### PR DESCRIPTION
Current behavior: The npm package downloads all binaries and the index.js file only selects the proper OS file to install - remaining binaries are unnecessary 

Expected behavior: index.js should check the github releases for the latest version, find the correct binary based on OS/archicture, and then only install the appropriate file 

Test cases:  

- Make sure “npm i” works properly, is globally installed
- running “basic …” commands works
- Test on mac/linux/windows
- Running “basic update” should reinstall with the latest release version